### PR TITLE
[DC-8691]  - Update the template mapping for pillar2 form id PL3

### DIFF
--- a/src/main/scala/uk/gov/hmrc/common/message/model/AlertEmailTemplateMapper.scala
+++ b/src/main/scala/uk/gov/hmrc/common/message/model/AlertEmailTemplateMapper.scala
@@ -31,8 +31,7 @@ trait AlertEmailTemplateMapper extends TemplateId {
     "IgnorePaperFiling",
     "2WSM-question",
     "2WSM-reply",
-    "CA001",
-    "PL3"
+    "CA001"
   )
 
   lazy val itsaTemplates: Map[String, String] = Map(
@@ -126,6 +125,7 @@ trait AlertEmailTemplateMapper extends TemplateId {
       case (form, _) if form.endsWith("oss")                               => "new_message_alert_ioss"
       case (form, _) if form.endsWith("oss_cy")                            => "new_message_alert_ioss_cy"
       case (form, _) if form.startsWith("niref")                           => s"newMessageAlert_$formId"
+      case (form, _) if form.startsWith("pl3")                             => s"new_message_alert_$formId"
       case (form, _) =>
         templatesToMapToNewMessageAlert.find(fId => form.startsWith(fId.toLowerCase)) match {
           case Some(formId)              => s"newMessageAlert_$formId"

--- a/src/test/scala/uk/gov/hmrc/common/message/model/AlertEmailTemplateMapperSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/common/message/model/AlertEmailTemplateMapperSpec.scala
@@ -190,7 +190,7 @@ class AlertEmailTemplateMapperSpec extends PlaySpec with AlertEmailTemplateMappe
     }
 
     "map Pillar2 formIds to newMessageAlert_formId templates" in {
-      emailTemplateFromMessageFormId("PL3") mustBe "newMessageAlert_PL3"
+      emailTemplateFromMessageFormId("PL3") mustBe "new_message_alert_PL3"
     }
   }
 


### PR DESCRIPTION
Description - Update template id and form id mapping as requested by BA team to maintain the consistency for Splunk logs

Old template id - newMessageAlert_PL3
New template id - new_message_alert_PL3